### PR TITLE
fix: improve detection of changes after pulling Simple subtree updates

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -38,28 +38,25 @@ jobs:
       - name: Pull updates from Simple subtree
         id: pull_subtree
         run: |
-          # This command pulls changes from the 'main' branch of the 'simple' repo
-          # into the 'simple' directory of the current repository.
-          #
-          # The '--squash' flag combines all upstream changes into a single commit.
-          # If you prefer to preserve individual commit history from the Simple repo,
-          # remove the '--squash' flag.
+          # Store the current HEAD commit
+          BEFORE_PULL=$(git rev-parse HEAD)
+          
+          # Perform the subtree pull
           git subtree pull --prefix simple simple main || echo "No updates from simple."
-
-      # Check if there are any changes after the subtree pull.
-      - name: Check for changes
-        id: check_changes
-        run: |
-          # Use git status to see if any changes occurred.
-          if [ -z "$(git status --porcelain)" ]; then
-            echo "changed=false" >> $GITHUB_OUTPUT
-          else
+          
+          # Store the new HEAD commit
+          AFTER_PULL=$(git rev-parse HEAD)
+          
+          # Compare commits to detect changes
+          if [ "$BEFORE_PULL" != "$AFTER_PULL" ]; then
             echo "changed=true" >> $GITHUB_OUTPUT
+          else
+            echo "changed=false" >> $GITHUB_OUTPUT
           fi
 
       # Create a pull request for the subtree updates if changes are detected.
       - name: Create Pull Request for subtree updates
-        if: steps.check_changes.outputs.changed == 'true'
+        if: steps.pull_subtree.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v4
         with:
           commit-message: 'chore: sync Simple subtree updates'


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/sync.yml` file to improve the subtree pull process and the detection of changes. The most important changes include storing the current and new HEAD commits before and after the subtree pull, and updating the method to check for changes.

Improvements to subtree pull process:

* [`.github/workflows/sync.yml`](diffhunk://#diff-147c24905d3ee9d7fb8197574238fb54e3d0e2c8bf95a360ea21d849314d7bf7L41-R59): Added commands to store the current HEAD commit before the subtree pull and the new HEAD commit after the pull. This helps in accurately detecting changes by comparing these commits.
* [`.github/workflows/sync.yml`](diffhunk://#diff-147c24905d3ee9d7fb8197574238fb54e3d0e2c8bf95a360ea21d849314d7bf7L41-R59): Updated the change detection logic to compare the stored HEAD commits instead of using `git status`. This ensures that any changes are correctly identified.
* [`.github/workflows/sync.yml`](diffhunk://#diff-147c24905d3ee9d7fb8197574238fb54e3d0e2c8bf95a360ea21d849314d7bf7L41-R59): Modified the conditional check for creating a pull request to use the updated change detection output.