### PR TITLE
feat: add CODEOWNERS file to define default reviewers for the repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @filipelautert and @jnewton03 will be requested for
+# review when someone opens a pull request.
+*       @filipelautert @jnewton03
+
+# Specific ownership for the simple subtree directory
+/simple/ @filipelautert @jnewton03


### PR DESCRIPTION
This pull request includes a small change to the `.github/CODEOWNERS` file. The change assigns default ownership to @filipelautert and @jnewton03 for the entire repository and specifies ownership for the `simple` directory.

Changes in ownership assignments:

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R1-R8): Added @filipelautert and @jnewton03 as default owners for the entire repository and specifically for the `simple` directory.