### PR TITLE
fix: enhance error handling during subtree pull in sync workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -41,8 +41,12 @@ jobs:
           # Store the current HEAD commit
           BEFORE_PULL=$(git rev-parse HEAD)
           
-          # Perform the subtree pull
-          git subtree pull --prefix simple simple main || echo "No updates from simple."
+          # Perform the subtree pull and capture its output.  Fail on error.
+          if ! OUTPUT=$(git subtree pull --prefix simple simple main 2>&1); then
+            echo "Error during subtree pull:"
+            echo "$OUTPUT"
+            exit 1
+          fi
           
           # Store the new HEAD commit
           AFTER_PULL=$(git rev-parse HEAD)

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -41,12 +41,8 @@ jobs:
           # Store the current HEAD commit
           BEFORE_PULL=$(git rev-parse HEAD)
           
-          # Perform the subtree pull and capture its output.  Fail on error.
-          if ! OUTPUT=$(git subtree pull --prefix simple simple main 2>&1); then
-            echo "Error during subtree pull:"
-            echo "$OUTPUT"
-            exit 1
-          fi
+          # Perform the subtree pull
+          git subtree pull --prefix simple simple main
           
           # Store the new HEAD commit
           AFTER_PULL=$(git rev-parse HEAD)


### PR DESCRIPTION
This pull request includes an important update to the `.github/workflows/sync.yml` file to improve error handling during the subtree pull operation.

Changes to error handling:

* [`.github/workflows/sync.yml`](diffhunk://#diff-147c24905d3ee9d7fb8197574238fb54e3d0e2c8bf95a360ea21d849314d7bf7L44-R49): Modified the subtree pull operation to capture its output and fail on error, providing more detailed error messages.