### PR TITLE
feat: add auto-merge functionality for subtree update pull requests

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -58,6 +58,7 @@ jobs:
       - name: Create Pull Request for subtree updates
         if: steps.pull_subtree.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v4
+        id: create-pr
         with:
           commit-message: 'chore: sync Simple subtree updates'
           branch: 'sync-simple-updates'
@@ -65,3 +66,9 @@ jobs:
           body: |
             This PR synchronizes the latest changes from the Simple repository
             into the subtree located in the `simple/` directory.
+
+      # Enable auto-merge on the PR
+      - name: Enable auto-merge
+        if: steps.create-pr.outputs.pull-request-number
+        run: |
+          gh pr merge --auto --merge "${{ steps.create-pr.outputs.pull-request-number }}"

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ This repository includes an automated workflow that syncs changes from the Simpl
 - Runs automatically at midnight UTC
 - Can be triggered manually via GitHub Actions
 - Creates a pull request when changes are detected
+- Automatically enables auto-merge on created PRs
 
 To manually trigger the sync:
 1. Go to the "Actions" tab in GitHub
@@ -121,11 +122,29 @@ To manually trigger the sync:
 The workflow will:
 - Pull latest changes from the Simple repository
 - Create a PR if there are any updates
+- Enable auto-merge on the PR
 - Use the branch name `sync-simple-updates` for the changes
+- Fail if there are merge conflicts (requiring manual intervention)
 
 To modify the sync schedule, edit the cron expression in `.github/workflows/sync.yml`:
 ```yaml
 on:
   schedule:
     - cron: '0 0 * * *'  # Runs every day at midnight UTC
+```
+
+#### Handling Sync Failures
+When the automatic sync encounters merge conflicts:
+1. The workflow will fail with an error message
+2. No PR will be created
+3. Manual intervention will be required to resolve conflicts
+
+To resolve conflicts manually:
+```bash
+git fetch simple
+git subtree pull --prefix simple simple main
+# Fix conflicts in the affected files
+git add .
+git commit -m "fix: resolve sync conflicts with Simple repository"
+git push
 ```


### PR DESCRIPTION
This pull request includes an enhancement to the GitHub Actions workflow for synchronizing updates from the Simple repository. The most important change is the addition of a step to enable auto-merge for the created pull request.

Enhancements to GitHub Actions workflow:

* [`.github/workflows/sync.yml`](diffhunk://#diff-147c24905d3ee9d7fb8197574238fb54e3d0e2c8bf95a360ea21d849314d7bf7R61-R74): Added a step to enable auto-merge on the pull request created for subtree updates by using the `gh pr merge --auto --merge` command.